### PR TITLE
feat: Wallet Blacklist

### DIFF
--- a/app/blacklist/page.tsx
+++ b/app/blacklist/page.tsx
@@ -1,0 +1,25 @@
+import { prisma } from "@/lib/db";
+import { BlacklistSearch } from "@/components/BlacklistSearch";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export default async function BlacklistPage() {
+  const entries = await prisma.blacklistedWallet.findMany({
+    orderBy: { confirmedAt: "desc" },
+  });
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-semibold text-white">Wallet Blacklist</h1>
+        <p className="mt-2 text-vampTextMuted text-sm">
+          Confirmed scammer wallets verified by the VCC team. Search by wallet address to
+          check if an address has been flagged.
+        </p>
+      </div>
+
+      <BlacklistSearch entries={entries} />
+    </div>
+  );
+}

--- a/components/BlacklistSearch.tsx
+++ b/components/BlacklistSearch.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useState, useMemo } from "react";
+
+interface BlacklistedWallet {
+  id: string;
+  walletAddress: string;
+  chain: string;
+  reason: string;
+  confirmedAt: Date;
+}
+
+export function BlacklistSearch({ entries }: { entries: BlacklistedWallet[] }) {
+  const [query, setQuery] = useState("");
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return entries;
+    return entries.filter((e) => e.walletAddress.toLowerCase().includes(q));
+  }, [query, entries]);
+
+  const isMatch = query.trim().length > 0 && filtered.length > 0 &&
+    filtered[0].walletAddress.toLowerCase() === query.trim().toLowerCase();
+
+  return (
+    <div className="space-y-4">
+      <div className="relative">
+        <input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search wallet address…"
+          className="w-full rounded-2xl border border-vampBorder bg-black/40 px-4 py-3 text-sm text-white placeholder-white/30 focus:outline-none focus:ring-1 focus:ring-vampAccent"
+        />
+        {query && (
+          <button
+            onClick={() => setQuery("")}
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-vampTextMuted hover:text-white"
+          >
+            ✕
+          </button>
+        )}
+      </div>
+
+      {query.trim() && (
+        <div
+          className={`rounded-2xl border px-4 py-3 text-sm font-medium ${
+            isMatch
+              ? "border-red-500/40 bg-red-500/10 text-red-400"
+              : "border-green-500/30 bg-green-500/10 text-green-400"
+          }`}
+        >
+          {isMatch
+            ? "⚠ This wallet is on the blacklist."
+            : filtered.length > 0
+            ? `${filtered.length} partial match${filtered.length !== 1 ? "es" : ""} found.`
+            : "✓ This wallet address was not found in the blacklist."}
+        </div>
+      )}
+
+      {entries.length === 0 ? (
+        <div className="rounded-2xl border border-vampBorder bg-black/40 p-6 text-vampTextMuted text-sm">
+          No blacklisted wallets yet.
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {filtered.map((e) => (
+            <div
+              key={e.id}
+              className="rounded-2xl border border-red-500/20 bg-red-500/5 p-4"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="font-mono text-sm text-white break-all">
+                    {e.walletAddress}
+                  </div>
+                  <div className="mt-0.5 text-xs text-vampTextMuted capitalize">
+                    Chain: {e.chain}
+                  </div>
+                </div>
+                <span className="shrink-0 text-xs px-2 py-0.5 rounded-full bg-red-500/15 text-red-400 border border-red-500/30">
+                  Blacklisted
+                </span>
+              </div>
+              <p className="mt-2 text-sm text-white/80">{e.reason}</p>
+              <div className="mt-2 text-xs text-vampTextMuted">
+                Confirmed {new Date(e.confirmedAt).toLocaleDateString()}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="text-xs text-vampTextMuted">
+        {entries.length} wallet{entries.length !== 1 ? "s" : ""} on the blacklist ·{" "}
+        <a href="/report" className="text-vampAccent hover:underline">
+          Report a suspicious wallet
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -15,6 +15,8 @@ export const NavBar: React.FC<NavBarProps> = ({ isAuthenticated }) => {
   const navItems = [
     { href: "/", label: "Home" },
     { href: "/directory", label: "Directory" },
+    { href: "/blacklist", label: "Blacklist" },
+    { href: "/report", label: "Report Scam" },
     { href: "/member", label: isAuthenticated ? "My Dashboard" : "Login" },
     { href: "/apply", label: "Apply" },
   ];

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -96,13 +96,24 @@ model Comment {
   id            String   @id @default(cuid())
   profileId     String
   profile       Profile  @relation(fields: [profileId], references: [id], onDelete: Cascade)
-  
+
   authorId      String
   author        Profile  @relation("AuthoredComments", fields: [authorId], references: [id], onDelete: Cascade)
-  
+
   content       String
   createdAt     DateTime @default(now())
 
   @@index([profileId])
   @@index([authorId])
+}
+
+model BlacklistedWallet {
+  id           String   @id @default(cuid())
+  walletAddress String   @unique
+  chain        String   @default("solana")
+  reason       String
+  scamReportId String?
+  confirmedAt  DateTime @default(now())
+
+  @@index([walletAddress])
 }


### PR DESCRIPTION
Closes #23

## Summary
- New public `/blacklist` page listing all confirmed scammer wallets
- Live client-side search by wallet address with exact-match warning banner
- `BlacklistedWallet` DB model with walletAddress, chain, reason, confirmedAt
- "Blacklist" nav link added; footer link on page to `/report` for new reports

## Test plan
- [ ] Visit `/blacklist` — shows empty state when no entries exist
- [ ] Search a wallet not in the list — shows green "not found" banner
- [ ] Add an entry to DB, search it — shows red "on the blacklist" banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)