### PR TITLE
feat: Trust Score System

### DIFF
--- a/app/admin/actions.ts
+++ b/app/admin/actions.ts
@@ -82,6 +82,27 @@ export async function deleteUser(profileId: string) {
   revalidatePath("/");
 }
 
+export async function adjustTrustScore(profileId: string, delta: number, reason: string) {
+  const member = await getMemberSession();
+  if (!member || !member.userRoles.includes("ADMIN")) throw new Error("Unauthorized");
+
+  const profile = await prisma.profile.findUnique({ where: { id: profileId }, select: { trustScore: true } });
+  if (!profile) throw new Error("Profile not found");
+
+  const newScore = Math.min(100, Math.max(0, profile.trustScore + delta));
+  const actualDelta = newScore - profile.trustScore;
+
+  await prisma.profile.update({ where: { id: profileId }, data: { trustScore: newScore } });
+  if (actualDelta !== 0) {
+    await prisma.trustScoreAudit.create({
+      data: { profileId, delta: actualDelta, reason, adminId: member.id },
+    });
+  }
+
+  revalidatePath("/admin");
+  revalidatePath(`/directory/${profileId}`);
+}
+
 export async function rejectProfile(id: string, note?: string) {
   await requireAdmin();
   const updated = await prisma.profile.update({

--- a/app/directory/[id]/page.tsx
+++ b/app/directory/[id]/page.tsx
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/db";
 import { notFound } from "next/navigation";
 import { getMemberSession } from "@/app/member/actions";
+import { TrustScorePanel } from "@/components/TrustScorePanel";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -16,7 +17,10 @@ export default async function DirectoryProfilePage({
 
   const profile = await prisma.profile.findUnique({
     where: { id },
-    include: { references: true },
+    include: {
+      references: true,
+      trustScoreAudits: { orderBy: { createdAt: "desc" }, take: 5 },
+    },
   });
 
   if (!profile) return notFound();
@@ -77,6 +81,13 @@ export default async function DirectoryProfilePage({
         <div>Chain: <span className="text-vampTextMuted">{profile.chain}</span></div>
         {profile.wallet && <div>Wallet: <span className="text-vampTextMuted break-all">{profile.wallet}</span></div>}
       </div>
+
+      {profile.status === "APPROVED" && (
+        <TrustScorePanel
+          score={profile.trustScore}
+          audits={profile.trustScoreAudits}
+        />
+      )}
 
       <div className="rounded-2xl border border-vampBorder bg-black/40 p-5">
         <div className="text-sm font-semibold text-white mb-3">References</div>

--- a/components/TrustScorePanel.tsx
+++ b/components/TrustScorePanel.tsx
@@ -1,0 +1,74 @@
+interface ScoreBreakdownItem {
+  label: string;
+  points: number;
+  earned: boolean;
+}
+
+interface TrustScorePanelProps {
+  score: number;
+  audits?: { delta: number; reason: string; createdAt: Date }[];
+}
+
+export function TrustScorePanel({ score, audits }: TrustScorePanelProps) {
+  const tier =
+    score >= 85 ? { label: "Elite", color: "text-yellow-400", bg: "bg-yellow-400/10 border-yellow-400/30" } :
+    score >= 50 ? { label: "Trusted", color: "text-blue-400", bg: "bg-blue-400/10 border-blue-400/30" } :
+    score > 0   ? { label: "Basic", color: "text-green-400", bg: "bg-green-400/10 border-green-400/30" } :
+                  { label: "Unscored", color: "text-vampTextMuted", bg: "bg-white/5 border-vampBorder" };
+
+  const pct = Math.min(score, 100);
+
+  return (
+    <div className="rounded-2xl border border-vampBorder bg-black/40 p-4 space-y-4">
+      <div className="flex items-center justify-between">
+        <div className="text-sm font-medium text-vampTextMuted uppercase tracking-wide">Trust Score</div>
+        <span className={`text-xs px-2 py-0.5 rounded-full border font-medium ${tier.bg} ${tier.color}`}>
+          {tier.label}
+        </span>
+      </div>
+
+      <div className="flex items-end gap-3">
+        <div className={`text-5xl font-bold ${tier.color}`}>{score}</div>
+        <div className="text-vampTextMuted text-sm mb-1">/ 100</div>
+      </div>
+
+      <div className="w-full h-2 rounded-full bg-white/10 overflow-hidden">
+        <div
+          className="h-full rounded-full bg-gradient-to-r from-vampAccent to-vampAccentSoft transition-all"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+
+      <div className="text-xs text-vampTextMuted space-y-1">
+        <div className="font-medium text-white/60 mb-2">Score breakdown</div>
+        {[
+          { label: "Approved member", pts: 20 },
+          { label: "References (up to 3)", pts: 30 },
+          { label: "Profile completeness", pts: 20 },
+          { label: "Skills & tags", pts: 10 },
+          { label: "Location listed", pts: 5 },
+          { label: "Account age (up to 90d)", pts: 15 },
+        ].map((item) => (
+          <div key={item.label} className="flex justify-between">
+            <span>{item.label}</span>
+            <span className="text-vampTextMuted">up to {item.pts} pts</span>
+          </div>
+        ))}
+      </div>
+
+      {audits && audits.length > 0 && (
+        <div className="space-y-1 pt-2 border-t border-vampBorder">
+          <div className="text-xs font-medium text-white/60 mb-2">Recent changes</div>
+          {audits.slice(0, 5).map((a, i) => (
+            <div key={i} className="flex justify-between text-xs text-vampTextMuted">
+              <span>{a.reason}</span>
+              <span className={a.delta >= 0 ? "text-green-400" : "text-red-400"}>
+                {a.delta >= 0 ? "+" : ""}{a.delta}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/lib/trustScore.ts
+++ b/lib/trustScore.ts
@@ -1,0 +1,71 @@
+import { prisma } from "./db";
+
+export async function computeTrustScore(profileId: string): Promise<number> {
+  const profile = await prisma.profile.findUnique({
+    where: { id: profileId },
+    include: { references: true },
+  });
+
+  if (!profile || profile.status !== "APPROVED") return 0;
+
+  let score = 0;
+
+  // Base: approved member
+  score += 20;
+
+  // References (up to 30 pts, 10 per reference, max 3)
+  score += Math.min(profile.references.length * 10, 30);
+
+  // Profile completeness (up to 20 pts)
+  if (profile.bio) score += 5;
+  if (profile.wallet) score += 5;
+  if (profile.website || profile.github || profile.linkedin) score += 5;
+  if (profile.telegram || profile.xHandle) score += 5;
+
+  // Skills and tags (up to 10 pts)
+  if (profile.skills.length >= 3) score += 5;
+  if (profile.tags.length >= 2) score += 5;
+
+  // Location listed (5 pts)
+  if (profile.location) score += 5;
+
+  // Account age bonus (up to 15 pts)
+  const ageMs = Date.now() - new Date(profile.createdAt).getTime();
+  const ageDays = ageMs / (1000 * 60 * 60 * 24);
+  if (ageDays >= 90) score += 15;
+  else if (ageDays >= 30) score += 8;
+  else if (ageDays >= 7) score += 3;
+
+  return Math.min(score, 100);
+}
+
+export async function refreshTrustScore(profileId: string, adminId?: string): Promise<number> {
+  const newScore = await computeTrustScore(profileId);
+
+  const current = await prisma.profile.findUnique({
+    where: { id: profileId },
+    select: { trustScore: true },
+  });
+
+  if (!current) return newScore;
+
+  const delta = newScore - current.trustScore;
+
+  await prisma.profile.update({
+    where: { id: profileId },
+    data: { trustScore: newScore },
+  });
+
+  if (delta !== 0) {
+    await prisma.trustScoreAudit.create({
+      data: {
+        profileId,
+        delta,
+        reason: adminId ? "Manual admin adjustment" : "Automatic recalculation",
+        adminId: adminId ?? null,
+      },
+    });
+  }
+
+  return newScore;
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -57,6 +57,10 @@ model Profile {
   reviewedAt   DateTime?
   reviewerNote String?
 
+  // Trust score (0-100) and audit trail
+  trustScore   Int          @default(0)
+  trustScoreAudits TrustScoreAudit[]
+
   references   Reference[]
   sessions     Session[]
   comments     Comment[]
@@ -96,13 +100,25 @@ model Comment {
   id            String   @id @default(cuid())
   profileId     String
   profile       Profile  @relation(fields: [profileId], references: [id], onDelete: Cascade)
-  
+
   authorId      String
   author        Profile  @relation("AuthoredComments", fields: [authorId], references: [id], onDelete: Cascade)
-  
+
   content       String
   createdAt     DateTime @default(now())
 
   @@index([profileId])
   @@index([authorId])
+}
+
+model TrustScoreAudit {
+  id        String   @id @default(cuid())
+  profileId String
+  profile   Profile  @relation(fields: [profileId], references: [id], onDelete: Cascade)
+  delta     Int
+  reason    String
+  adminId   String?
+  createdAt DateTime @default(now())
+
+  @@index([profileId])
 }


### PR DESCRIPTION
Closes #25

## Summary
- `trustScore Int @default(0)` added to Profile model
- `TrustScoreAudit` model logs every score change (delta, reason, adminId)
- `lib/trustScore.ts` — `computeTrustScore()` calculates score from: approved status (20), references (10 ea, max 30), profile completeness (20), skills/tags (10), location (5), account age (15)
- `TrustScorePanel` component shown on member profile pages with score bar, tier badge, breakdown, and recent audit log
- `adjustTrustScore` admin action for manual adjustments with reason tracking

## Scoring tiers
| Score | Badge |
|-------|-------|
| 85–100 | Elite |
| 50–84 | Trusted |
| 1–49 | Basic |

## Test plan
- [ ] View a member profile — trust score panel appears
- [ ] Score reflects reference count and profile completeness
- [ ] Admin adjusts score — audit log entry created

🤖 Generated with [Claude Code](https://claude.com/claude-code)