### PR TITLE
feat: Badge System

### DIFF
--- a/app/directory/[id]/page.tsx
+++ b/app/directory/[id]/page.tsx
@@ -1,6 +1,8 @@
 import { prisma } from "@/lib/db";
 import { notFound } from "next/navigation";
 import { getMemberSession } from "@/app/member/actions";
+import { Badge } from "@/components/Badge";
+import { getBadgeFromScore } from "@/lib/badge";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -35,10 +37,21 @@ export default async function DirectoryProfilePage({
   return (
     <div className="max-w-4xl space-y-6">
       <div>
-        <h1 className="text-3xl font-semibold text-white">
-          {profile.displayName}
-          {profile.handle ? <span className="text-vampTextMuted text-base"> · @{profile.handle}</span> : null}
-        </h1>
+        <div className="flex items-center gap-3">
+          <h1 className="text-3xl font-semibold text-white">
+            {profile.displayName}
+            {profile.handle ? <span className="text-vampTextMuted text-base"> · @{profile.handle}</span> : null}
+          </h1>
+          {profile.status === "APPROVED" && (
+            <Badge
+              level={
+                (profile as any).badgeLevel ??
+                getBadgeFromScore((profile as any).trustScore ?? 0, true)
+              }
+              size="lg"
+            />
+          )}
+        </div>
         <div className="mt-1 text-vampTextMuted">
           {profile.submissionRole}{profile.location ? ` · ${profile.location}` : ""}
         </div>

--- a/app/directory/page.tsx
+++ b/app/directory/page.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link";
 import { prisma } from "@/lib/db";
+import { Badge } from "@/components/Badge";
+import { getBadgeFromScore } from "@/lib/badge";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -17,6 +19,8 @@ export default async function DirectoryPage() {
       location: true,
       tags: true,
       skills: true,
+      trustScore: true,
+      badgeLevel: true,
     },
   });
 
@@ -30,40 +34,45 @@ export default async function DirectoryPage() {
         </div>
       ) : (
         <div className="grid gap-4 md:grid-cols-2">
-          {profiles.map((p) => (
-            <Link
-              key={p.id}
-              href={`/directory/${p.id}`}
-              className="rounded-2xl border border-vampBorder bg-black/40 p-4 hover:bg-white/5 transition-colors"
-            >
-              <div className="flex items-start justify-between gap-3">
-                <div>
-                  <div className="text-lg font-semibold text-white">
-                    {p.displayName}
-                    {p.handle ? <span className="text-vampTextMuted text-sm"> · @{p.handle}</span> : null}
+          {profiles.map((p) => {
+            const badge = (p.badgeLevel as "BASIC" | "TRUSTED" | "ELITE" | null) ??
+              getBadgeFromScore(p.trustScore, true);
+            return (
+              <Link
+                key={p.id}
+                href={`/directory/${p.id}`}
+                className="rounded-2xl border border-vampBorder bg-black/40 p-4 hover:bg-white/5 transition-colors"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <div className="text-lg font-semibold text-white">
+                      {p.displayName}
+                      {p.handle ? <span className="text-vampTextMuted text-sm"> · @{p.handle}</span> : null}
+                    </div>
+                    <div className="text-sm text-vampTextMuted">
+                      {p.submissionRole}{p.location ? ` · ${p.location}` : ""}
+                    </div>
                   </div>
-                  <div className="text-sm text-vampTextMuted">
-                    {p.submissionRole}{p.location ? ` · ${p.location}` : ""}
-                  </div>
+                  <Badge level={badge} size="sm" />
                 </div>
-              </div>
 
-              {(p.skills.length > 0 || p.tags.length > 0) && (
-                <div className="mt-3 flex flex-wrap gap-2">
-                  {p.skills.slice(0, 6).map((x) => (
-                    <span key={`s-${p.id}-${x}`} className="text-xs rounded-full bg-white/5 border border-vampBorder px-2 py-1 text-white/90">
-                      {x}
-                    </span>
-                  ))}
-                  {p.tags.slice(0, 6).map((x) => (
-                    <span key={`t-${p.id}-${x}`} className="text-xs rounded-full bg-vampAccent/15 border border-vampAccent/30 px-2 py-1 text-white/90">
-                      {x}
-                    </span>
-                  ))}
-                </div>
-              )}
-            </Link>
-          ))}
+                {(p.skills.length > 0 || p.tags.length > 0) && (
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    {p.skills.slice(0, 6).map((x) => (
+                      <span key={`s-${p.id}-${x}`} className="text-xs rounded-full bg-white/5 border border-vampBorder px-2 py-1 text-white/90">
+                        {x}
+                      </span>
+                    ))}
+                    {p.tags.slice(0, 6).map((x) => (
+                      <span key={`t-${p.id}-${x}`} className="text-xs rounded-full bg-vampAccent/15 border border-vampAccent/30 px-2 py-1 text-white/90">
+                        {x}
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </Link>
+            );
+          })}
         </div>
       )}
     </div>

--- a/components/Badge.tsx
+++ b/components/Badge.tsx
@@ -1,0 +1,28 @@
+import { BADGE_CONFIG, type BadgeLevel } from "@/lib/badge";
+
+interface BadgeProps {
+  level: BadgeLevel;
+  size?: "sm" | "md" | "lg";
+}
+
+export function Badge({ level, size = "md" }: BadgeProps) {
+  if (!level) return null;
+
+  const cfg = BADGE_CONFIG[level];
+
+  const sizeClasses = {
+    sm: "text-[10px] px-1.5 py-0.5 gap-0.5",
+    md: "text-xs px-2 py-0.5 gap-1",
+    lg: "text-sm px-3 py-1 gap-1.5",
+  }[size];
+
+  return (
+    <span
+      title={cfg.description}
+      className={`inline-flex items-center rounded-full border font-medium ${sizeClasses} ${cfg.color} ${cfg.border} ${cfg.bg} ${cfg.glow}`}
+    >
+      <span>{cfg.icon}</span>
+      <span>{cfg.label}</span>
+    </span>
+  );
+}

--- a/lib/badge.ts
+++ b/lib/badge.ts
@@ -1,0 +1,41 @@
+export type BadgeLevel = "BASIC" | "TRUSTED" | "ELITE" | null;
+
+export function getBadgeFromScore(score: number, isApproved: boolean): BadgeLevel {
+  if (!isApproved || score === 0) return null;
+  if (score >= 85) return "ELITE";
+  if (score >= 50) return "TRUSTED";
+  return "BASIC";
+}
+
+export const BADGE_CONFIG = {
+  ELITE: {
+    label: "Elite",
+    description: "Top-tier, community-validated professional",
+    minScore: 85,
+    color: "text-yellow-400",
+    border: "border-yellow-400/40",
+    bg: "bg-yellow-400/10",
+    glow: "shadow-[0_0_8px_rgba(250,204,21,0.3)]",
+    icon: "⭐",
+  },
+  TRUSTED: {
+    label: "Trusted",
+    description: "Strong on-chain history & references",
+    minScore: 50,
+    color: "text-blue-400",
+    border: "border-blue-400/40",
+    bg: "bg-blue-400/10",
+    glow: "shadow-[0_0_8px_rgba(96,165,250,0.3)]",
+    icon: "✦",
+  },
+  BASIC: {
+    label: "Basic",
+    description: "Verified VCC member",
+    minScore: 1,
+    color: "text-green-400",
+    border: "border-green-400/40",
+    bg: "bg-green-400/10",
+    glow: "",
+    icon: "✓",
+  },
+} as const;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,6 +16,12 @@ enum ReviewStatus {
   REJECTED
 }
 
+enum BadgeLevel {
+  BASIC
+  TRUSTED
+  ELITE
+}
+
 enum UserRole {
   MEMBER
   REVIEWER
@@ -56,6 +62,10 @@ model Profile {
   status       ReviewStatus?
   reviewedAt   DateTime?
   reviewerNote String?
+
+  // Trust score and badge
+  trustScore   Int          @default(0)
+  badgeLevel   BadgeLevel?
 
   references   Reference[]
   sessions     Session[]


### PR DESCRIPTION
Closes #26

## Summary
- `BadgeLevel` enum (BASIC/TRUSTED/ELITE) and `badgeLevel` field added to Profile
- `lib/badge.ts` — `getBadgeFromScore()` derives badge from trustScore; `BADGE_CONFIG` defines styles per tier
- `Badge` component with `sm/md/lg` sizes, distinct color/border/glow per tier
- Directory cards show badge (sm) top-right of each card
- Profile detail page shows badge (lg) next to member name

## Tiers
| Badge | Score | Style |
|-------|-------|-------|
| Basic ✓ | 1–49 | Green |
| Trusted ✦ | 50–84 | Blue |
| Elite ⭐ | 85–100 | Yellow/gold glow |

## Test plan
- [ ] Member with trustScore 0 — no badge shown
- [ ] Member with score 25 — Basic badge shown
- [ ] Member with score 60 — Trusted badge shown
- [ ] Member with score 90 — Elite badge with glow shown
- [ ] Badge visible on directory card AND profile page

🤖 Generated with [Claude Code](https://claude.com/claude-code)