### PR TITLE
feat: Advanced Filters for Directory

### DIFF
--- a/app/directory/page.tsx
+++ b/app/directory/page.tsx
@@ -1,69 +1,132 @@
 import Link from "next/link";
 import { prisma } from "@/lib/db";
+import { Suspense } from "react";
+import { DirectoryFilters } from "@/components/DirectoryFilters";
+import { getBadgeFromScore } from "@/lib/badge";
+import { Badge } from "@/components/Badge";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
-export default async function DirectoryPage() {
-  const profiles = await prisma.profile.findMany({
-    where: { status: "APPROVED" },
-    orderBy: { createdAt: "desc" },
-    take: 60,
-    select: {
-      id: true,
-      displayName: true,
-      handle: true,
-      submissionRole: true,
-      location: true,
-      tags: true,
-      skills: true,
-    },
-  });
+interface PageProps {
+  searchParams: Promise<{ location?: string; role?: string; badge?: string; skill?: string | string[] }>;
+}
+
+export default async function DirectoryPage({ searchParams }: PageProps) {
+  const sp = await searchParams;
+
+  const filterLocation = sp.location ?? null;
+  const filterRole = sp.role ?? null;
+  const filterBadge = sp.badge ?? null;
+  const filterSkills = sp.skill ? (Array.isArray(sp.skill) ? sp.skill : [sp.skill]) : [];
+
+  // Build WHERE clause
+  const where: Record<string, unknown> = { status: "APPROVED" };
+  if (filterLocation) where.location = { contains: filterLocation, mode: "insensitive" };
+  if (filterRole) where.submissionRole = { contains: filterRole, mode: "insensitive" };
+  if (filterSkills.length > 0) where.skills = { hasSome: filterSkills };
+  if (filterBadge === "ELITE") where.trustScore = { gte: 85 };
+  else if (filterBadge === "TRUSTED") where.trustScore = { gte: 50, lt: 85 };
+  else if (filterBadge === "BASIC") where.trustScore = { gt: 0, lt: 50 };
+
+  const [profiles, allApproved] = await Promise.all([
+    prisma.profile.findMany({
+      where,
+      orderBy: [{ trustScore: "desc" }, { createdAt: "desc" }],
+      take: 60,
+      select: {
+        id: true,
+        displayName: true,
+        handle: true,
+        submissionRole: true,
+        location: true,
+        tags: true,
+        skills: true,
+        trustScore: true,
+        badgeLevel: true,
+      },
+    }),
+    prisma.profile.findMany({
+      where: { status: "APPROVED" },
+      select: { location: true, submissionRole: true, skills: true },
+    }),
+  ]);
+
+  // Derive filter options from all approved profiles
+  const allLocations = [...new Set(allApproved.map((p) => p.location).filter(Boolean) as string[])].sort();
+  const allRoles = [...new Set(allApproved.map((p) => p.submissionRole).filter(Boolean) as string[])].sort();
+  const allSkills = [...new Set(allApproved.flatMap((p) => p.skills))].sort();
+
+  const activeCount = [filterLocation, filterRole, filterBadge, ...filterSkills].filter(Boolean).length;
 
   return (
     <div className="space-y-6">
       <h1 className="text-3xl font-semibold text-white">Directory</h1>
 
+      <Suspense>
+        <DirectoryFilters
+          allLocations={allLocations}
+          allRoles={allRoles}
+          allSkills={allSkills}
+          activeCount={activeCount}
+        />
+      </Suspense>
+
+      {activeCount > 0 && (
+        <div className="text-sm text-vampTextMuted">
+          {profiles.length} result{profiles.length !== 1 ? "s" : ""} for active filters
+        </div>
+      )}
+
       {profiles.length === 0 ? (
         <div className="rounded-2xl border border-vampBorder bg-black/40 p-6 text-vampTextMuted">
-          No approved profiles yet.
+          {activeCount > 0 ? "No members match your filters." : "No approved profiles yet."}
         </div>
       ) : (
         <div className="grid gap-4 md:grid-cols-2">
-          {profiles.map((p) => (
-            <Link
-              key={p.id}
-              href={`/directory/${p.id}`}
-              className="rounded-2xl border border-vampBorder bg-black/40 p-4 hover:bg-white/5 transition-colors"
-            >
-              <div className="flex items-start justify-between gap-3">
-                <div>
-                  <div className="text-lg font-semibold text-white">
-                    {p.displayName}
-                    {p.handle ? <span className="text-vampTextMuted text-sm"> · @{p.handle}</span> : null}
+          {profiles.map((p) => {
+            const badge = (p.badgeLevel as "BASIC" | "TRUSTED" | "ELITE" | null) ??
+              getBadgeFromScore(p.trustScore, true);
+            return (
+              <Link
+                key={p.id}
+                href={`/directory/${p.id}`}
+                className="rounded-2xl border border-vampBorder bg-black/40 p-4 hover:bg-white/5 transition-colors"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <div className="text-lg font-semibold text-white">
+                      {p.displayName}
+                      {p.handle ? <span className="text-vampTextMuted text-sm"> · @{p.handle}</span> : null}
+                    </div>
+                    <div className="text-sm text-vampTextMuted">
+                      {p.submissionRole}{p.location ? ` · ${p.location}` : ""}
+                    </div>
                   </div>
-                  <div className="text-sm text-vampTextMuted">
-                    {p.submissionRole}{p.location ? ` · ${p.location}` : ""}
-                  </div>
+                  <Badge level={badge} size="sm" />
                 </div>
-              </div>
 
-              {(p.skills.length > 0 || p.tags.length > 0) && (
-                <div className="mt-3 flex flex-wrap gap-2">
-                  {p.skills.slice(0, 6).map((x) => (
-                    <span key={`s-${p.id}-${x}`} className="text-xs rounded-full bg-white/5 border border-vampBorder px-2 py-1 text-white/90">
-                      {x}
-                    </span>
-                  ))}
-                  {p.tags.slice(0, 6).map((x) => (
-                    <span key={`t-${p.id}-${x}`} className="text-xs rounded-full bg-vampAccent/15 border border-vampAccent/30 px-2 py-1 text-white/90">
-                      {x}
-                    </span>
-                  ))}
-                </div>
-              )}
-            </Link>
-          ))}
+                {(p.skills.length > 0 || p.tags.length > 0) && (
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    {p.skills.slice(0, 6).map((x) => (
+                      <span key={`s-${p.id}-${x}`} className={`text-xs rounded-full px-2 py-1 border ${
+                        filterSkills.includes(x)
+                          ? "bg-vampAccent/20 border-vampAccent text-white"
+                          : "bg-white/5 border-vampBorder text-white/90"
+                      }`}>
+                        {x}
+                      </span>
+                    ))}
+                    {p.tags.slice(0, 6).map((x) => (
+                      <span key={`t-${p.id}-${x}`} className="text-xs rounded-full bg-vampAccent/15 border border-vampAccent/30 px-2 py-1 text-white/90">
+                        {x}
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </Link>
+            );
+          })}
         </div>
       )}
     </div>

--- a/components/Badge.tsx
+++ b/components/Badge.tsx
@@ -1,0 +1,28 @@
+import { BADGE_CONFIG, type BadgeLevel } from "@/lib/badge";
+
+interface BadgeProps {
+  level: BadgeLevel;
+  size?: "sm" | "md" | "lg";
+}
+
+export function Badge({ level, size = "md" }: BadgeProps) {
+  if (!level) return null;
+
+  const cfg = BADGE_CONFIG[level];
+
+  const sizeClasses = {
+    sm: "text-[10px] px-1.5 py-0.5 gap-0.5",
+    md: "text-xs px-2 py-0.5 gap-1",
+    lg: "text-sm px-3 py-1 gap-1.5",
+  }[size];
+
+  return (
+    <span
+      title={cfg.description}
+      className={`inline-flex items-center rounded-full border font-medium ${sizeClasses} ${cfg.color} ${cfg.border} ${cfg.bg} ${cfg.glow}`}
+    >
+      <span>{cfg.icon}</span>
+      <span>{cfg.label}</span>
+    </span>
+  );
+}

--- a/components/DirectoryFilters.tsx
+++ b/components/DirectoryFilters.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useCallback } from "react";
+
+interface DirectoryFiltersProps {
+  allLocations: string[];
+  allRoles: string[];
+  allSkills: string[];
+  activeCount: number;
+}
+
+export function DirectoryFilters({
+  allLocations,
+  allRoles,
+  allSkills,
+  activeCount,
+}: DirectoryFiltersProps) {
+  const router = useRouter();
+  const sp = useSearchParams();
+
+  const location = sp.get("location") ?? "";
+  const role = sp.get("role") ?? "";
+  const badge = sp.get("badge") ?? "";
+  const skills = sp.getAll("skill");
+
+  function update(key: string, value: string | null) {
+    const params = new URLSearchParams(sp.toString());
+    if (value) {
+      params.set(key, value);
+    } else {
+      params.delete(key);
+    }
+    router.replace(`/directory?${params.toString()}`);
+  }
+
+  function toggleSkill(skill: string) {
+    const params = new URLSearchParams(sp.toString());
+    const current = params.getAll("skill");
+    params.delete("skill");
+    if (current.includes(skill)) {
+      current.filter((s) => s !== skill).forEach((s) => params.append("skill", s));
+    } else {
+      [...current, skill].forEach((s) => params.append("skill", s));
+    }
+    router.replace(`/directory?${params.toString()}`);
+  }
+
+  function clearAll() {
+    router.replace("/directory");
+  }
+
+  return (
+    <div className="rounded-2xl border border-vampBorder bg-black/40 p-4 space-y-4">
+      <div className="flex items-center justify-between">
+        <div className="text-sm font-medium text-white">Filters</div>
+        {activeCount > 0 && (
+          <button
+            onClick={clearAll}
+            className="text-xs text-vampTextMuted hover:text-white transition-colors"
+          >
+            Clear all ({activeCount})
+          </button>
+        )}
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+        {/* Location */}
+        <div className="space-y-1">
+          <label className="text-xs font-medium text-vampTextMuted uppercase tracking-wide">
+            Location
+          </label>
+          <select
+            value={location}
+            onChange={(e) => update("location", e.target.value || null)}
+            className="w-full rounded-xl border border-vampBorder bg-black/60 px-3 py-2 text-sm text-white focus:outline-none focus:ring-1 focus:ring-vampAccent"
+          >
+            <option value="">All locations</option>
+            {allLocations.map((l) => (
+              <option key={l} value={l}>
+                {l}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Role */}
+        <div className="space-y-1">
+          <label className="text-xs font-medium text-vampTextMuted uppercase tracking-wide">
+            Role
+          </label>
+          <select
+            value={role}
+            onChange={(e) => update("role", e.target.value || null)}
+            className="w-full rounded-xl border border-vampBorder bg-black/60 px-3 py-2 text-sm text-white focus:outline-none focus:ring-1 focus:ring-vampAccent"
+          >
+            <option value="">All roles</option>
+            {allRoles.map((r) => (
+              <option key={r} value={r}>
+                {r}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Badge */}
+        <div className="space-y-1">
+          <label className="text-xs font-medium text-vampTextMuted uppercase tracking-wide">
+            Badge
+          </label>
+          <select
+            value={badge}
+            onChange={(e) => update("badge", e.target.value || null)}
+            className="w-full rounded-xl border border-vampBorder bg-black/60 px-3 py-2 text-sm text-white focus:outline-none focus:ring-1 focus:ring-vampAccent"
+          >
+            <option value="">All badges</option>
+            <option value="ELITE">⭐ Elite (85+)</option>
+            <option value="TRUSTED">✦ Trusted (50+)</option>
+            <option value="BASIC">✓ Basic</option>
+          </select>
+        </div>
+      </div>
+
+      {/* Skills multi-select */}
+      {allSkills.length > 0 && (
+        <div className="space-y-2">
+          <label className="text-xs font-medium text-vampTextMuted uppercase tracking-wide">
+            Skills
+          </label>
+          <div className="flex flex-wrap gap-1.5">
+            {allSkills.map((s) => {
+              const active = skills.includes(s);
+              return (
+                <button
+                  key={s}
+                  onClick={() => toggleSkill(s)}
+                  className={`text-xs rounded-full px-2.5 py-1 border transition-colors ${
+                    active
+                      ? "bg-vampAccent/20 border-vampAccent text-white"
+                      : "bg-white/5 border-vampBorder text-vampTextMuted hover:text-white hover:border-white/30"
+                  }`}
+                >
+                  {s}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/lib/badge.ts
+++ b/lib/badge.ts
@@ -1,0 +1,41 @@
+export type BadgeLevel = "BASIC" | "TRUSTED" | "ELITE" | null;
+
+export function getBadgeFromScore(score: number, isApproved: boolean): BadgeLevel {
+  if (!isApproved || score === 0) return null;
+  if (score >= 85) return "ELITE";
+  if (score >= 50) return "TRUSTED";
+  return "BASIC";
+}
+
+export const BADGE_CONFIG = {
+  ELITE: {
+    label: "Elite",
+    description: "Top-tier, community-validated professional",
+    minScore: 85,
+    color: "text-yellow-400",
+    border: "border-yellow-400/40",
+    bg: "bg-yellow-400/10",
+    glow: "shadow-[0_0_8px_rgba(250,204,21,0.3)]",
+    icon: "⭐",
+  },
+  TRUSTED: {
+    label: "Trusted",
+    description: "Strong on-chain history & references",
+    minScore: 50,
+    color: "text-blue-400",
+    border: "border-blue-400/40",
+    bg: "bg-blue-400/10",
+    glow: "shadow-[0_0_8px_rgba(96,165,250,0.3)]",
+    icon: "✦",
+  },
+  BASIC: {
+    label: "Basic",
+    description: "Verified VCC member",
+    minScore: 1,
+    color: "text-green-400",
+    border: "border-green-400/40",
+    bg: "bg-green-400/10",
+    glow: "",
+    icon: "✓",
+  },
+} as const;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,6 +16,12 @@ enum ReviewStatus {
   REJECTED
 }
 
+enum BadgeLevel {
+  BASIC
+  TRUSTED
+  ELITE
+}
+
 enum UserRole {
   MEMBER
   REVIEWER
@@ -56,6 +62,10 @@ model Profile {
   status       ReviewStatus?
   reviewedAt   DateTime?
   reviewerNote String?
+
+  // Trust score and badge
+  trustScore   Int          @default(0)
+  badgeLevel   BadgeLevel?
 
   references   Reference[]
   sessions     Session[]


### PR DESCRIPTION
Closes #27

## Summary
- Filter panel on `/directory` with location (select), role (select), badge level (select), and skills (multi-select chips)
- Filters applied server-side via URL query params — links are shareable
- Active filter count badge with "Clear all" button
- Results sorted by trust score descending
- Active skill filters highlighted on matching directory cards
- Includes BadgeLevel enum, trustScore field, Badge component and badge lib (duplicated from #26 for standalone operation)

## Filter fields
| Filter | Type | Behavior |
|--------|------|---------|
| Location | Select | Contains match (case-insensitive) |
| Role | Select | Contains match (case-insensitive) |
| Badge | Select | trustScore range query |
| Skills | Multi-select chips | `hasSome` match (OR logic) |

## Test plan
- [ ] Visit `/directory` — filter panel visible above cards
- [ ] Select a location — only matching members shown
- [ ] Select "Elite" badge — only members with score 85+ shown
- [ ] Click multiple skill chips — members with any of those skills shown
- [ ] Share the URL with filters — same results load for another user
- [ ] Clear all filters — full directory restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)