### PR TITLE
feat: scam reports support wallets and projects

### DIFF
--- a/app/blacklist/page.tsx
+++ b/app/blacklist/page.tsx
@@ -5,21 +5,25 @@ export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
 export default async function BlacklistPage() {
-  const entries = await prisma.blacklistedWallet.findMany({
-    orderBy: { confirmedAt: "desc" },
-  });
+  const [wallets, confirmedProjects] = await Promise.all([
+    prisma.blacklistedWallet.findMany({ orderBy: { confirmedAt: "desc" } }),
+    prisma.scamReport.findMany({
+      where: { status: "CONFIRMED", reportType: "project" },
+      orderBy: { reviewedAt: "desc" },
+    }),
+  ]);
 
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-3xl font-semibold text-white">Wallet Blacklist</h1>
+        <h1 className="text-3xl font-semibold text-white">Blacklist</h1>
         <p className="mt-2 text-vampTextMuted text-sm">
-          Confirmed scammer wallets verified by the VCC team. Search by wallet address to
-          check if an address has been flagged.
+          Confirmed scam wallets and projects verified by the VCC team. Search by address
+          to check if it has been flagged.
         </p>
       </div>
 
-      <BlacklistSearch entries={entries} />
+      <BlacklistSearch wallets={wallets} projects={confirmedProjects} />
     </div>
   );
 }

--- a/app/report/actions.ts
+++ b/app/report/actions.ts
@@ -10,17 +10,14 @@ export async function submitScamReport(formData: FormData) {
   const ip = ipHeader.split(",")[0].trim();
 
   const rl = checkRateLimit({ key: `scam-report:${ip}`, limit: 3, windowMs: 60 * 60 * 1000 });
-  if (!rl.allowed) {
-    throw new Error("Too many reports submitted. Please wait before trying again.");
-  }
+  if (!rl.allowed) throw new Error("Too many reports submitted. Please wait before trying again.");
 
-  const walletAddress = (formData.get("walletAddress") as string)?.trim();
+  const reportType = (formData.get("reportType") as string) === "project" ? "project" : "wallet";
   const chain = (formData.get("chain") as string)?.trim() || "solana";
   const projectName = (formData.get("projectName") as string)?.trim() || null;
   const description = (formData.get("description") as string)?.trim();
   const evidenceRaw = (formData.get("evidenceLinks") as string)?.trim();
 
-  if (!walletAddress) throw new Error("Wallet address is required.");
   if (!description || description.length < 20)
     throw new Error("Please provide a description of at least 20 characters.");
 
@@ -28,22 +25,26 @@ export async function submitScamReport(formData: FormData) {
     ? evidenceRaw.split("\n").map((l) => l.trim()).filter(Boolean)
     : [];
 
-  await prisma.scamReport.create({
-    data: {
-      walletAddress,
-      chain,
-      projectName,
-      description,
-      evidenceLinks,
-      reporterIp: ip,
-    },
-  });
+  if (reportType === "wallet") {
+    const walletAddress = (formData.get("walletAddress") as string)?.trim();
+    if (!walletAddress) throw new Error("Wallet address is required.");
+
+    await prisma.scamReport.create({
+      data: { reportType, walletAddress, chain, projectName, description, evidenceLinks, reporterIp: ip },
+    });
+  } else {
+    const contractAddress = (formData.get("contractAddress") as string)?.trim();
+    if (!contractAddress) throw new Error("Contract address is required.");
+    if (!projectName) throw new Error("Project name is required.");
+
+    await prisma.scamReport.create({
+      data: { reportType, contractAddress, chain, projectName, description, evidenceLinks, reporterIp: ip },
+    });
+  }
 }
 
 export async function getScamReports() {
-  return prisma.scamReport.findMany({
-    orderBy: { createdAt: "desc" },
-  });
+  return prisma.scamReport.findMany({ orderBy: { createdAt: "desc" } });
 }
 
 export async function updateScamReportStatus(

--- a/app/report/page.tsx
+++ b/app/report/page.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { submitScamReport } from "./actions";
 
 export default function ReportPage() {
+  const [reportType, setReportType] = useState<"wallet" | "project">("wallet");
   const [pending, setPending] = useState(false);
   const [success, setSuccess] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -27,7 +28,7 @@ export default function ReportPage() {
       <div>
         <h1 className="text-3xl font-semibold text-white">Report a Scam</h1>
         <p className="mt-2 text-vampTextMuted text-sm">
-          Submit suspicious wallets or projects for manual admin review. All reports are
+          Submit a suspicious wallet or project for manual admin review. All reports are
           kept confidential and reviewed before any action is taken.
         </p>
       </div>
@@ -41,18 +42,62 @@ export default function ReportPage() {
         </div>
       ) : (
         <form onSubmit={handleSubmit} className="space-y-4">
+          {/* Type toggle */}
+          <div className="flex rounded-xl border border-vampBorder overflow-hidden">
+            <button
+              type="button"
+              onClick={() => setReportType("wallet")}
+              className={`flex-1 py-2.5 text-sm font-medium transition-colors ${
+                reportType === "wallet"
+                  ? "bg-vampAccent text-white"
+                  : "bg-black/40 text-vampTextMuted hover:text-white"
+              }`}
+            >
+              Wallet
+            </button>
+            <button
+              type="button"
+              onClick={() => setReportType("project")}
+              className={`flex-1 py-2.5 text-sm font-medium transition-colors ${
+                reportType === "project"
+                  ? "bg-vampAccent text-white"
+                  : "bg-black/40 text-vampTextMuted hover:text-white"
+              }`}
+            >
+              Project
+            </button>
+          </div>
+
+          <input type="hidden" name="reportType" value={reportType} />
+
           <div className="rounded-2xl border border-vampBorder bg-black/40 p-6 space-y-4">
             <div className="grid grid-cols-3 gap-3">
               <div className="col-span-2 space-y-1">
-                <label className="text-xs font-medium text-vampTextMuted uppercase tracking-wide">
-                  Wallet Address *
-                </label>
-                <input
-                  name="walletAddress"
-                  required
-                  placeholder="e.g. 7xKXt..."
-                  className="w-full rounded-xl border border-vampBorder bg-black/60 px-3 py-2 text-sm text-white placeholder-white/30 focus:outline-none focus:ring-1 focus:ring-vampAccent"
-                />
+                {reportType === "wallet" ? (
+                  <>
+                    <label className="text-xs font-medium text-vampTextMuted uppercase tracking-wide">
+                      Wallet Address *
+                    </label>
+                    <input
+                      name="walletAddress"
+                      required
+                      placeholder="e.g. 7xKXt…"
+                      className="w-full rounded-xl border border-vampBorder bg-black/60 px-3 py-2 text-sm text-white placeholder-white/30 focus:outline-none focus:ring-1 focus:ring-vampAccent"
+                    />
+                  </>
+                ) : (
+                  <>
+                    <label className="text-xs font-medium text-vampTextMuted uppercase tracking-wide">
+                      Contract Address (CA) *
+                    </label>
+                    <input
+                      name="contractAddress"
+                      required
+                      placeholder="e.g. 7xKXt…"
+                      className="w-full rounded-xl border border-vampBorder bg-black/60 px-3 py-2 text-sm text-white placeholder-white/30 focus:outline-none focus:ring-1 focus:ring-vampAccent"
+                    />
+                  </>
+                )}
               </div>
               <div className="space-y-1">
                 <label className="text-xs font-medium text-vampTextMuted uppercase tracking-wide">
@@ -72,10 +117,11 @@ export default function ReportPage() {
 
             <div className="space-y-1">
               <label className="text-xs font-medium text-vampTextMuted uppercase tracking-wide">
-                Project Name (optional)
+                {reportType === "project" ? "Project Name *" : "Project Name (optional)"}
               </label>
               <input
                 name="projectName"
+                required={reportType === "project"}
                 placeholder="e.g. FakeSwap Protocol"
                 className="w-full rounded-xl border border-vampBorder bg-black/60 px-3 py-2 text-sm text-white placeholder-white/30 focus:outline-none focus:ring-1 focus:ring-vampAccent"
               />
@@ -90,7 +136,7 @@ export default function ReportPage() {
                 required
                 minLength={20}
                 rows={4}
-                placeholder="Describe the suspicious activity in detail..."
+                placeholder="Describe the suspicious activity in detail…"
                 className="w-full rounded-xl border border-vampBorder bg-black/60 px-3 py-2 text-sm text-white placeholder-white/30 focus:outline-none focus:ring-1 focus:ring-vampAccent resize-none"
               />
             </div>
@@ -102,7 +148,7 @@ export default function ReportPage() {
               <textarea
                 name="evidenceLinks"
                 rows={3}
-                placeholder={"https://solscan.io/tx/...\nhttps://twitter.com/..."}
+                placeholder={"https://solscan.io/tx/…\nhttps://twitter.com/…"}
                 className="w-full rounded-xl border border-vampBorder bg-black/60 px-3 py-2 text-sm text-white placeholder-white/30 focus:outline-none focus:ring-1 focus:ring-vampAccent resize-none"
               />
             </div>
@@ -119,7 +165,7 @@ export default function ReportPage() {
             disabled={pending}
             className="w-full rounded-full bg-vampAccent px-6 py-2.5 text-sm font-medium text-white shadow-vampGlow hover:bg-vampAccentSoft transition-colors disabled:opacity-50"
           >
-            {pending ? "Submitting…" : "Submit Report"}
+            {pending ? "Submitting…" : `Submit ${reportType === "project" ? "Project" : "Wallet"} Report`}
           </button>
         </form>
       )}

--- a/components/BlacklistSearch.tsx
+++ b/components/BlacklistSearch.tsx
@@ -10,17 +10,51 @@ interface BlacklistedWallet {
   confirmedAt: Date;
 }
 
-export function BlacklistSearch({ entries }: { entries: BlacklistedWallet[] }) {
+interface ConfirmedProject {
+  id: string;
+  projectName: string | null;
+  contractAddress: string | null;
+  chain: string;
+  description: string;
+  reviewedAt: Date | null;
+}
+
+interface Props {
+  wallets: BlacklistedWallet[];
+  projects: ConfirmedProject[];
+}
+
+export function BlacklistSearch({ wallets, projects }: Props) {
   const [query, setQuery] = useState("");
+  const [tab, setTab] = useState<"all" | "wallets" | "projects">("all");
 
-  const filtered = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    if (!q) return entries;
-    return entries.filter((e) => e.walletAddress.toLowerCase().includes(q));
-  }, [query, entries]);
+  const q = query.trim().toLowerCase();
 
-  const isMatch = query.trim().length > 0 && filtered.length > 0 &&
-    filtered[0].walletAddress.toLowerCase() === query.trim().toLowerCase();
+  const filteredWallets = useMemo(() =>
+    q ? wallets.filter((e) => e.walletAddress.toLowerCase().includes(q)) : wallets,
+    [q, wallets]
+  );
+
+  const filteredProjects = useMemo(() =>
+    q ? projects.filter((p) =>
+      (p.contractAddress?.toLowerCase().includes(q)) ||
+      (p.projectName?.toLowerCase().includes(q))
+    ) : projects,
+    [q, projects]
+  );
+
+  const showWallets = tab === "all" || tab === "wallets";
+  const showProjects = tab === "all" || tab === "projects";
+
+  const exactWalletMatch = q && filteredWallets.some(
+    (e) => e.walletAddress.toLowerCase() === q
+  );
+  const exactProjectMatch = q && filteredProjects.some(
+    (p) => p.contractAddress?.toLowerCase() === q
+  );
+  const anyExactMatch = exactWalletMatch || exactProjectMatch;
+  const totalResults = (showWallets ? filteredWallets.length : 0) + (showProjects ? filteredProjects.length : 0);
+  const totalEntries = wallets.length + projects.length;
 
   return (
     <div className="space-y-4">
@@ -28,7 +62,7 @@ export function BlacklistSearch({ entries }: { entries: BlacklistedWallet[] }) {
         <input
           value={query}
           onChange={(e) => setQuery(e.target.value)}
-          placeholder="Search wallet address…"
+          placeholder="Search by wallet address, CA, or project name…"
           className="w-full rounded-2xl border border-vampBorder bg-black/40 px-4 py-3 text-sm text-white placeholder-white/30 focus:outline-none focus:ring-1 focus:ring-vampAccent"
         />
         {query && (
@@ -41,41 +75,54 @@ export function BlacklistSearch({ entries }: { entries: BlacklistedWallet[] }) {
         )}
       </div>
 
-      {query.trim() && (
-        <div
-          className={`rounded-2xl border px-4 py-3 text-sm font-medium ${
-            isMatch
-              ? "border-red-500/40 bg-red-500/10 text-red-400"
-              : "border-green-500/30 bg-green-500/10 text-green-400"
-          }`}
-        >
-          {isMatch
-            ? "⚠ This wallet is on the blacklist."
-            : filtered.length > 0
-            ? `${filtered.length} partial match${filtered.length !== 1 ? "es" : ""} found.`
-            : "✓ This wallet address was not found in the blacklist."}
+      {/* Tab filter */}
+      <div className="flex gap-2">
+        {(["all", "wallets", "projects"] as const).map((t) => (
+          <button
+            key={t}
+            onClick={() => setTab(t)}
+            className={`px-3 py-1 rounded-full text-xs font-medium border transition-colors ${
+              tab === t
+                ? "bg-vampAccent/20 border-vampAccent text-white"
+                : "border-vampBorder text-vampTextMuted hover:text-white bg-black/40"
+            }`}
+          >
+            {t === "all" ? `All (${totalEntries})` : t === "wallets" ? `Wallets (${wallets.length})` : `Projects (${projects.length})`}
+          </button>
+        ))}
+      </div>
+
+      {q && (
+        <div className={`rounded-2xl border px-4 py-3 text-sm font-medium ${
+          anyExactMatch
+            ? "border-red-500/40 bg-red-500/10 text-red-400"
+            : "border-green-500/30 bg-green-500/10 text-green-400"
+        }`}>
+          {anyExactMatch
+            ? `⚠ This address is on the blacklist${exactProjectMatch ? " (scam project)" : ""}.`
+            : totalResults > 0
+            ? `${totalResults} partial match${totalResults !== 1 ? "es" : ""} found.`
+            : "✓ This address was not found in the blacklist."}
         </div>
       )}
 
-      {entries.length === 0 ? (
+      {totalEntries === 0 ? (
         <div className="rounded-2xl border border-vampBorder bg-black/40 p-6 text-vampTextMuted text-sm">
-          No blacklisted wallets yet.
+          No blacklisted entries yet.
         </div>
       ) : (
         <div className="space-y-2">
-          {filtered.map((e) => (
-            <div
-              key={e.id}
-              className="rounded-2xl border border-red-500/20 bg-red-500/5 p-4"
-            >
+          {showWallets && filteredWallets.map((e) => (
+            <div key={e.id} className="rounded-2xl border border-red-500/20 bg-red-500/5 p-4">
               <div className="flex items-start justify-between gap-3">
                 <div className="min-w-0">
-                  <div className="font-mono text-sm text-white break-all">
-                    {e.walletAddress}
+                  <div className="flex items-center gap-2 mb-1">
+                    <span className="text-[10px] px-1.5 py-0.5 rounded-full border font-medium text-blue-400 border-blue-400/40 bg-blue-400/10">
+                      Wallet
+                    </span>
                   </div>
-                  <div className="mt-0.5 text-xs text-vampTextMuted capitalize">
-                    Chain: {e.chain}
-                  </div>
+                  <div className="font-mono text-sm text-white break-all">{e.walletAddress}</div>
+                  <div className="mt-0.5 text-xs text-vampTextMuted capitalize">Chain: {e.chain}</div>
                 </div>
                 <span className="shrink-0 text-xs px-2 py-0.5 rounded-full bg-red-500/15 text-red-400 border border-red-500/30">
                   Blacklisted
@@ -87,13 +134,43 @@ export function BlacklistSearch({ entries }: { entries: BlacklistedWallet[] }) {
               </div>
             </div>
           ))}
+
+          {showProjects && filteredProjects.map((p) => (
+            <div key={p.id} className="rounded-2xl border border-red-500/20 bg-red-500/5 p-4">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2 mb-1">
+                    <span className="text-[10px] px-1.5 py-0.5 rounded-full border font-medium text-purple-400 border-purple-400/40 bg-purple-400/10">
+                      Project
+                    </span>
+                    {p.projectName && (
+                      <span className="text-sm font-semibold text-white">{p.projectName}</span>
+                    )}
+                  </div>
+                  {p.contractAddress && (
+                    <div className="font-mono text-sm text-white/70 break-all">CA: {p.contractAddress}</div>
+                  )}
+                  <div className="mt-0.5 text-xs text-vampTextMuted capitalize">Chain: {p.chain}</div>
+                </div>
+                <span className="shrink-0 text-xs px-2 py-0.5 rounded-full bg-red-500/15 text-red-400 border border-red-500/30">
+                  Confirmed Scam
+                </span>
+              </div>
+              <p className="mt-2 text-sm text-white/80">{p.description}</p>
+              {p.reviewedAt && (
+                <div className="mt-2 text-xs text-vampTextMuted">
+                  Confirmed {new Date(p.reviewedAt).toLocaleDateString()}
+                </div>
+              )}
+            </div>
+          ))}
         </div>
       )}
 
       <div className="text-xs text-vampTextMuted">
-        {entries.length} wallet{entries.length !== 1 ? "s" : ""} on the blacklist ·{" "}
+        {totalEntries} entr{totalEntries !== 1 ? "ies" : "y"} on the blacklist ·{" "}
         <a href="/report" className="text-vampAccent hover:underline">
-          Report a suspicious wallet
+          Report a scam
         </a>
       </div>
     </div>

--- a/components/ScamReportRow.tsx
+++ b/components/ScamReportRow.tsx
@@ -5,7 +5,9 @@ import { reviewScamReport } from "@/app/admin/actions";
 
 interface ScamReport {
   id: string;
-  walletAddress: string;
+  reportType: string;
+  walletAddress: string | null;
+  contractAddress: string | null;
   chain: string;
   projectName: string | null;
   description: string;
@@ -28,17 +30,29 @@ export function ScamReportRow({ report }: { report: ScamReport }) {
     }
   }
 
+  const isProject = report.reportType === "project";
+  const address = isProject ? report.contractAddress : report.walletAddress;
+
   return (
     <div className="rounded-2xl border border-vampBorder bg-black/40 p-4 space-y-3">
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
-          <div className="font-mono text-sm text-white break-all">
-            {report.walletAddress}
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className={`text-[10px] px-1.5 py-0.5 rounded-full border font-medium ${
+              isProject
+                ? "text-purple-400 border-purple-400/40 bg-purple-400/10"
+                : "text-blue-400 border-blue-400/40 bg-blue-400/10"
+            }`}>
+              {isProject ? "Project" : "Wallet"}
+            </span>
+            {report.projectName && (
+              <span className="text-sm font-semibold text-white">{report.projectName}</span>
+            )}
+          </div>
+          <div className="mt-1 font-mono text-sm text-white/70 break-all">
+            {isProject ? "CA: " : ""}{address}
             <span className="ml-2 text-xs text-vampTextMuted capitalize">({report.chain})</span>
           </div>
-          {report.projectName && (
-            <div className="mt-0.5 text-sm text-vampTextMuted">Project: {report.projectName}</div>
-          )}
         </div>
         <span className="shrink-0 text-xs px-2 py-0.5 rounded-full bg-yellow-500/15 text-yellow-400 border border-yellow-500/30">
           {report.status}

--- a/prisma/migrations/20260502000000_scam_report_type/migration.sql
+++ b/prisma/migrations/20260502000000_scam_report_type/migration.sql
@@ -1,0 +1,7 @@
+-- AlterTable: add reportType and contractAddress, make walletAddress optional
+ALTER TABLE "ScamReport" ADD COLUMN "reportType" TEXT NOT NULL DEFAULT 'wallet';
+ALTER TABLE "ScamReport" ADD COLUMN "contractAddress" TEXT;
+ALTER TABLE "ScamReport" ALTER COLUMN "walletAddress" DROP NOT NULL;
+
+-- DropIndex: old walletAddress index (was on non-nullable column)
+DROP INDEX IF EXISTS "ScamReport_walletAddress_idx";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -126,19 +126,20 @@ model Comment {
 }
 
 model ScamReport {
-  id            String           @id @default(cuid())
-  walletAddress String
-  chain         String           @default("solana")
-  projectName   String?
-  description   String
-  evidenceLinks String[]         @default([])
-  status        ScamReportStatus @default(PENDING)
-  reporterIp    String?
-  adminNote     String?
-  reviewedAt    DateTime?
-  createdAt     DateTime         @default(now())
+  id              String           @id @default(cuid())
+  reportType      String           @default("wallet") // "wallet" | "project"
+  walletAddress   String?
+  contractAddress String?
+  chain           String           @default("solana")
+  projectName     String?
+  description     String
+  evidenceLinks   String[]         @default([])
+  status          ScamReportStatus @default(PENDING)
+  reporterIp      String?
+  adminNote       String?
+  reviewedAt      DateTime?
+  createdAt       DateTime         @default(now())
 
-  @@index([walletAddress])
   @@index([status])
 }
 


### PR DESCRIPTION
## Summary
- `/report` page has a **Wallet / Project toggle** — wallet reports collect a wallet address, project reports collect a CA + required project name
- `ScamReport` schema: `walletAddress` is now nullable, adds `contractAddress` and `reportType` columns
- Admin `ScamReportRow` shows a type badge (blue=Wallet, purple=Project) and the correct address label
- `/blacklist` now pulls in confirmed project scam reports alongside `BlacklistedWallet` entries
- Blacklist search covers wallet address, CA, and project name; tab filter for All / Wallets / Projects

## Migration
Run `prisma/migrations/20260502000000_scam_report_type/migration.sql` after deploying.

## Test plan
- [ ] Submit a wallet report — wallet address field shown, saves with reportType="wallet"
- [ ] Submit a project report — CA + project name fields shown, project name required
- [ ] Admin confirms a project report — appears on /blacklist under Projects tab
- [ ] Search /blacklist by CA — matched project shown with red "Confirmed Scam" badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)